### PR TITLE
Add 'hindbrain' and 'schwann' datasets to docs

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -13,4 +13,6 @@
     zebrafish_grn
     murine_nc
     human_limb
+    hindbrain
+    schwann
 ```


### PR DESCRIPTION
Updated the datasets API documentation to include the new 'hindbrain' and 'schwann' datasets in the available list.