### PR TITLE
Refactor release workflow to use build and twine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,48 @@
 name: Release
 
 on:
-    push:
-        tags:
-            - "*.*.*"
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
-    release:
-        name: Release
-        runs-on: ubuntu-latest
-        steps:
-            # will use ref/SHA that triggered it
-            - name: Checkout code
-              uses: actions/checkout@v3
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-            - name: Set up Python 3.10
-              uses: actions/setup-python@v4
-              with:
-                  python-version: "3.9"
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'pip'
 
-            - name: Install poetry
-              uses: abatilo/actions-poetry@v2.0.0
-              with:
-                  poetry-version: 1.4.2
+    - name: Install build tools
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build twine
 
-            - name: Build project for distribution
-              run: poetry build
+    - name: Build package
+      run: python -m build
 
-            - name: Check Version
-              id: check-version
-              run: |
-                  [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-                    || echo ::set-output name=prerelease::true
+    - name: Verify metadata
+      run: twine check dist/*
 
-            - name: Publish to PyPI
-              env:
-                  POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-              run: poetry publish
+    - name: Upload build artifacts (for debugging/manual runs)
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/*
+
+    # Publish only when triggered by a tag push matching v*.*.*:
+    - name: Publish to PyPI with Twine
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TWINE_API_TOKEN }}
+      run: |
+        twine upload --skip-existing dist/*


### PR DESCRIPTION
Updated the GitHub Actions release workflow to use Python's build and twine instead of poetry for packaging and publishing. The workflow now triggers on tags prefixed with 'v', uses updated action versions, adds artifact upload for debugging, and improves metadata verification before publishing to PyPI.