### PR TITLE
chore(desp): remove `velovi` because not needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "scvelo >=0.3.2",
   "scvi-tools >=1.0.0,<1.2.1",
   "scikit-learn >=0.21.2",
-  "velovi >=0.3.1",
   "torchode >=0.1.6",
   "cellrank >=2.0.0",
   "matplotlib >=3.7.3",


### PR DESCRIPTION
when trying to packaging it to a conda package, found `velovi` as a redundant dependency, it is not referenced anywhere.