### PR TITLE
Fix ReadTheDocs build by updating OS to ubuntu-24.04

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-    os: ubuntu-20.04
+    os: ubuntu-24.04
     tools:
         python: "3.10"
         


### PR DESCRIPTION
ubuntu-20.04 is no longer a supported build.os value on ReadTheDocs.