### PR TITLE
Add mplscience as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "rich >=10.0.0",
   "cloudpickle>=3.0.0",
   "tqdm >=4.60.0",
+  "mplscience >=0.0.7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
mplscience is imported across the plotting module but was not declared in pyproject.toml.