### PR TITLE
Fix stale API doc references in tools.md and plotting.md

### DIFF
--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -11,6 +11,9 @@
    plotting.cellfate_perturbation
    plotting.simulated_visit_diff
    plotting.regulatory_network
-   plotting.markov_screen
-   plotting.driver_TF_ranking
+   plotting.plot_visits_dist
+   plotting.plot_visits_dist_screen
+   plotting.plot_TF_success_rate
+   plotting.plot_grn_weight
+   plotting.plot_TF_regulon
 ```

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -13,9 +13,10 @@
    tools.in_silico_block_simulation
    tools.in_silico_block_regulation_simulation
    tools.TFScanning_func
-   tools.TFscreening
+   tools.markov_density_screening
    tools.TFscreening_wrapper
    tools.markov_density_simulation
    tools.simulated_visit_diff
    tools.regulation_scanning
+   tools.compute_TF_regulon
 ```


### PR DESCRIPTION
- tools.md: TFscreening -> markov_density_screening; add compute_TF_regulon.
- plotting.md: drop non-existent markov_screen / driver_TF_ranking; add plot_visits_dist, plot_visits_dist_screen, plot_TF_success_rate, plot_grn_weight, plot_TF_regulon.